### PR TITLE
Fix prefix for sharing keys after encounter ends

### DIFF
--- a/Communications.lua
+++ b/Communications.lua
@@ -293,7 +293,7 @@ AstralEvents:Register('ENCOUNTER_START', function()
 	end, 'encStart')
 
 AstralEvents:Register('ENCOUNTER_END', function()
-	AstralComs:RegisterPrefix('GUID', 'request', PushKeyList)
+	AstralComs:RegisterPrefix('GUILD', 'request', PushKeyList)
 	end, 'encStop')
 
 -- Checks to see if we zone into a raid instance,


### PR DESCRIPTION
Currently after any raid or m+ encounter, the addon isn't sharing keys to guild due to an incorrect prefix registration. This should fix it.