### PR TITLE
Key Information.lua: Store player key info in correct format

### DIFF
--- a/AstralKeys.toc
+++ b/AstralKeys.toc
@@ -2,7 +2,7 @@
 ## Title: Astral Keys
 ## Notes: Keystone Manager for Guilds and Friends
 ## Author: Astral
-## Version: 3.41
+## Version: 3.42
 ## SavedVariables: AstralKeys, AstralCharacters, AstralKeysSettings, AstralMinimap, AstralAffixes, AstralLists, AstralUnits
 
 Init.lua

--- a/Key Information.lua
+++ b/Key Information.lua
@@ -21,7 +21,7 @@ local function UpdateWeekly()
 	else
 		local id = e.UnitID(e.Player())
 		if id then
-			AstralKeys[id][5] = characterWeeklyBest
+			AstralKeys[id].weekly_best = characterWeeklyBest
 			e.UpdateFrames()
 		end
 	end
@@ -140,12 +140,19 @@ function e.FindKeyStone(sendUpdate, anounceKey)
 		else -- Not in a guild, who are you people? Whatever, gotta make it work for them as well
 			local id = e.UnitID(e.Player())
 			if id then -- Are we in the DB already?
-				AstralKeys[id][3] = tonumber(mapID)
-				AstralKeys[id][4] = tonumber(keyLevel)
-				AstralKeys[id][6] = e.Week
-				AstralKeys[id][7] = e.WeekTime()
+				AstralKeys[id].dungeon_id = tonumber(mapID)
+				AstralKeys[id].key_level = tonumber(keyLevel)
+				AstralKeys[id].week = e.Week
+				AstralKeys[id].time_stamp = e.WeekTime()
 			else -- Nope, ok, let's add them to the DB manually.
-				AstralKeys[#AstralKeys + 1] = {e.Player(), e.PlayerClass(), tonumber(mapID), tonumber(keyLevel), e.Week, e.WeekTime()}
+				AstralKeys[#AstralKeys + 1] = {
+					unit = e.Player(),
+					class = e.PlayerClass(),
+					dungeon_id = tonumber(mapID),
+					key_level = tonumber(keyLevel),
+					week = e.Week,
+					time_stamp = e.WeekTime(),
+				}
 				e.SetUnitID(e.Player(), #AstralKeys)
 			end
 		end


### PR DESCRIPTION
In `Key Information.lua`, information about the current player is populated using numeric indices instead of string keys. Subsequent lookups of this information would fail. It seems the refactor in 55b8d94bf4053b861516c95bb8171e5022ddb3eb wasn't quite complete.

The bug seems to be masked for players in guilds since the guild scan will also repopulate the player's key information in the correct format, so the issue only gets observed by players without guilds: https://github.com/astralguild/AstralKeys/issues/10#issuecomment-774513943

The version has been bumped to 3.42.

This should fix the `bad argument #3 to 'strformat'` error as observed in #7, #10, as well as numerous comments like https://www.curseforge.com/wow/addons/astral-keys?comment=309.

    Message: Interface\AddOns\AstralKeys\Lists\Friends.lua:299: bad argument #3 to 'strformat' (string expected, got nil)