### PR TITLE
9.1.5. Backdrop Fix

### DIFF
--- a/Frame.lua
+++ b/Frame.lua
@@ -389,7 +389,7 @@ AstralKeyFrame.background = AstralKeyFrame:CreateTexture(nil, 'BACKGROUND')
 AstralKeyFrame.background:SetAllPoints(AstralKeyFrame)
 AstralKeyFrame.background:SetColorTexture(0, 0, 0, 0.8)
 
-local AstralKeyToolTip = CreateFrame( "GameTooltip", "AstralKeyToolTip", AAFrame, "GameTooltipTemplate" )
+local AstralKeyToolTip = CreateFrame( "GameTooltip", "AstralKeyToolTip", AAFrame, "BackdropTemplate,GameTooltipTemplate" )
 AstralKeyToolTip:SetOwner(AstralKeyFrame, "ANCHOR_CURSOR")
 AstralKeyToolTip:SetScript('OnShow', function(self)
 	self:SetBackdrop({


### PR DESCRIPTION
Corrects the tooltip error introduced by change to 9.1.5's handling of backdrops in Tooltips.

Credit to Hyphie24 on Curseforge and Gello on WoW Official Forums for identifying this fix.