### PR TITLE
Legion Timewalking Reporting

### DIFF
--- a/Affixes.lua
+++ b/Affixes.lua
@@ -64,6 +64,14 @@ local AFFIX_ROTATION = {
 	{ TYRANNICAL, RAGING, QUAKING },
 }
 
+-- Timewalking Affixes
+local INFERNAL = 129
+
+local LEGION_AFFIX_ROTATION = {
+	{ TYRANNICAL, BURSTING, VOLCANIC, INFERNAL },
+	{ FORTIFIED, SANGUINE, QUAKING, INFERNAL }
+}
+
 local AFFIX_INFO = {}
 local SEASON_AFFIX = 0
 local ROTATION_WEEK_POSITION = 0
@@ -165,6 +173,23 @@ end
 -- This is always the season affix, this doesn't get changed in a rotation
 function addon.AffixFour()
 	return SEASON_AFFIX
+end
+
+-- These are hardcoded and should be updated once we get back into the Timewalking event
+function addon.TimewalkingAffixOne() 
+	return LEGION_AFFIX_ROTATION[0][1]
+end
+
+function addon.TimewalkingAffixTwo()
+	return LEGION_AFFIX_ROTATION[0][2]
+end
+
+function addon.TimewaklingAffixThree()
+	return LEGION_AFFIX_ROTATION[0][3]
+end
+
+function addon.TimewalkingAffixFour()
+	return LEGION_AFFIX_ROTATION[0][4]
 end
 
 function addon.AffixName(id)

--- a/Communications.lua
+++ b/Communications.lua
@@ -300,6 +300,7 @@ local function ParseGuildChatCommands(text)
 				local keyLink = addon.CreateKeyLink(addon.UnitMapID(unitID), addon.UnitKeyLevel(unitID))
 				if not keyLink then return end -- Something went wrong
 				SendChatMessage(string.format('Astral Keys: %s', keyLink), 'GUILD')
+				ReportTimewalkingKey('GUILD')
 			else
 				if AstralKeysSettings.general.report_on_message.no_key then
 					SendChatMessage(strformat('%s: %s', 'Astral Keys', L['NO_KEY']), 'GUILD')
@@ -320,6 +321,7 @@ local function ParsePartyChatCommands(text)
 				local keyLink = addon.CreateKeyLink(addon.UnitMapID(unitID), addon.UnitKeyLevel(unitID))
 				if not keyLink then return end -- Something went wrong
 				SendChatMessage(string.format('Astral Keys: %s', keyLink), 'PARTY')
+				ReportTimewalkingKey('PARTY')	
 			else
 				if AstralKeysSettings.general.report_on_message.no_key then
 					SendChatMessage(strformat('%s: %s', 'Astral Keys', L['NO_KEY']), 'PARTY')
@@ -330,6 +332,21 @@ local function ParsePartyChatCommands(text)
 end
 AstralEvents:Register('CHAT_MSG_PARTY', ParsePartyChatCommands, 'parsepartychat')
 AstralEvents:Register('CHAT_MSG_PARTY_LEADER', ParsePartyChatCommands, 'parsepartychat')
+
+function ReportTimewalkingKey(reportType) 
+	local timeWalkingLink 
+	for bag = 0, NUM_BAG_SLOTS do
+		local numSlots = GetContainerNumSlots(bag)
+		for slot = 1, numSlots do
+			if (GetContainerItemID(bag, slot) == addon.TIMEWALKINGKEY_ITEMID) then
+				timeWalkingLink = GetContainerItemLink(bag, slot)
+				break
+			end
+		end
+	end
+	if not timeWalkingLink then return end -- something went wrong, or key doesn't exist this week
+	SendChatMessage(string.format('Astral Keys: %s', link), reportType)
+end
 
 local function ParseRaidChatCommands(text)
 	if UnitLevel('player') ~= addon.EXPANSION_LEVEL then return end -- Don't bother checking anything if the unit is unable to acquire a key
@@ -350,6 +367,7 @@ local function ParseRaidChatCommands(text)
 				end
 				if not link then return end -- something went wrong
 				SendChatMessage(string.format('Astral Keys: %s', link), 'RAID')	
+				ReportTimewalkingKey('RAID')
 			else
 				if AstralKeysSettings.general.report_on_message.no_key then
 					SendChatMessage(strformat('%s: %s', 'Astral Keys', L['NO_KEY']), 'RAID')

--- a/Key Information.lua
+++ b/Key Information.lua
@@ -10,6 +10,7 @@ COLOUR[4] = 'ffff8000' -- Legendary
 COLOUR[5] = 'ffe6cc80' -- Artifact
 
 addon.MYTHICKEY_ITEMID = 180653
+addon.TIMEWALKINGKEY_ITEMID = 187786
 
 local MapIds = {}
 
@@ -78,6 +79,26 @@ function addon.CreateKeyLink(mapID, keyLevel)
 		return strformat('|c' .. COLOUR[3] .. '|Hkeystone:%d:%d:%d:%d:%d:%d:%d|h[%s %s (%d)]|h|r', addon.MYTHICKEY_ITEMID, mapID, keyLevel, thisAff1, thisAff2, thisAff3, thisAff4, L['KEYSTONE'], mapName, keyLevel):gsub('\124\124', '\124')
 	end
 end
+
+-- Prints out the same link as the CreateKeyLink but only if the Timewalking Key is found. Otherwise nothing is done.
+function addon.CreateTimewalkingKeyLink(mapID, keyLevel)
+   local mapName = addon.GetMapName(mapID, true)
+   local thisAff1, thisAff2, thisAff3, thisAff4 = 0
+	if keyLevel > 1 then
+	 thisAff1 = addon.TimewalkingAffixOne()
+	end
+	if keyLevel > 3 then
+	 thisAff2 = addon.TimewalkingAffixTwo()
+	end
+	if keyLevel > 6 then
+	 thisAff3 = addon.TimewalkingAffixThree()
+	end
+	if keyLevel > 8 then
+	 thisAff4 = addon.TimewalkingAffixFour()
+	end
+	return strformat('|c' .. COLOUR[3] .. '|Hkeystone:%d:%d:%d:%d:%d:%d:%d|h[%s %s (%d)]|h|r', addon.TIMEWALKINGKEY_ITEMID, mapID, keyLevel, thisAff1, thisAff2, thisAff3, thisAff4, L['KEYSTONE'], mapName, keyLevel):gsub('\124\124', '\124')
+end
+
 
 AstralEvents:Register('CHALLENGE_MODE_COMPLETED', function()
 	C_Timer.After(3, function()


### PR DESCRIPTION
If a user has a Mythic+ Timewalking Keystone (only from Legion
currently), the "!keys" command should execute it in Guild, Party, or
Raid.