### PR TITLE
Fixed localization-hyperlink for italian client

### DIFF
--- a/Localization/itIT.lua
+++ b/Localization/itIT.lua
@@ -1,7 +1,7 @@
 local L = select(2, ...).L('itIT')
 
 -- Default string for keystone
-L['KEYSTONE'] = 'Keystone:'
+L['KEYSTONE'] = 'Chiave del Potere:'
 
 -- Default tab names
 L['GUILD'] = GUILD
@@ -15,34 +15,56 @@ L['DUNGEON'] = DUNGEONS
 L['CHARACTER'] = CHARACTER
 
 -- Subsection Headers
-L['CHARACTERS'] = 'CHARACTERS'
-L['AFFIXES'] = 'AFFIXES'
+L['CHARACTERS'] = 'PERSONAGGI'
+L['AFFIXES'] = 'MODIFICATORI'
 
 -- Character Labels
-L['CURRENT_KEY'] = 'CURRENT'
-L['WEEKLY_BEST'] = 'WKLY BEST'
+L['CURRENT_KEY'] = 'Corrente'
+L['WEEKLY_BEST'] = 'Migl sett'
 
-L['CHARACTER_DUNGEON_NOT_RAN'] = 'No mythic+ ran'
-L['CHARACTER_KEY_NOT_FOUND'] = 'No key found'
+L['CHARACTER_DUNGEON_NOT_RAN'] = 'Nessuna run M+'
+L['CHARACTER_KEY_NOT_FOUND'] = 'Nessuna chiave trovata'
 
 
 -- Dropdown menu selections
+L['REPORT_TO'] = 'Linka in'
 L['Whisper'] = WHISPER
 L['INVITE'] = INVITE
 L['SUGGEST_INVITE'] = SUGGEST_INVITE
 L['REQUEST_INVITE'] = REQUEST_INVITE
 L['CANCEL'] = CANCEL
+L['NEW_LIST_DESCRIPTION'] = 'Nuovo nome lista'
+L['CREATE_NEW_LIST'] = 'Crea nuova lista'
+L['REMOVE_UNIT_FROM_LIST'] = 'Rimuovi da lista'
+L['ADD_TO_LIST'] = 'Aggiungi unità alla lista'
+L['ADD_REMOVE_LIST'] = 'Aggiungi o cancella lista'
+L['DELETE_LIST'] = 'Cancella lista'
+L['LIST_ADD_HELPER_TEXT'] = 'Aggiungi unità alla lista cliccando con il testo destro su una unità nella tua lista di GILDA o AMICI'
+L['OKAY'] = 'ОК'
 
 -- Announce messages
-L['ANNOUNCE_NEW_KEY'] = 'Astral Keys: New key %s'
+L['ANNOUNCE_NEW_KEY'] = 'Astral Keys: Nuova chiave %s'
 L['NO_KEY'] = 'No key'
-L['KEYS_RESPOND_ON_NO_KEY'] = 'Respond even if you do not have a key'
+L['KEYS_RESPOND_ON_NO_KEY'] = 'Rispondi anche se non hai chiavi'
 
 
 -- Search field texts
-L['FILTER_TEXT_DUNGEON'] = 'Filter by dungeon'
-L['FILTER_TEXT_CHARACTER'] = 'Filter by character name'
+L['FILTER_TEXT_DUNGEON'] = 'Filtra per dungeon'
+L['FILTER_TEXT_CHARACTER'] = 'Filtra per nome'
 
 -- Options
-L['!KEYS_DESC'] = 'Respond to !keys command in the following chat channels'
-L['EXPANDED_TOOLTIP'] = 'Show affix description in the tooltip'
+L['!KEYS_DESC'] = 'Rispondi al comando !keys nei seguenti canali di chat'
+L['EXPANDED_TOOLTIP'] = 'Mostra descrizione dei modificatori nel tooltip'
+L['GENERAL OPTIONS'] = 'Opzioni generali'
+L['Show offline players'] = 'Mostra giocatori offline'
+L['Show Minimap button'] = 'Mostra bottone minimappa'
+L['Show current key in tooltip'] = 'Mostra chiave corrente in tooltip'
+L['Display offline below online'] = 'Mostra offline sotto online'
+L['Announce new keys to party'] = 'Annuncia nuove chiavi in gruppo'
+L['Announce new keys to guild'] = 'Annuncia nuove chiavi in gilda'
+L['!keys chat command'] = 'Comando chat !keys'
+L['SYNC OPTIONS'] = 'Opzioni di sincronizzazione'
+L['Sync with friends'] = 'Sincronizza con gli amici'
+L['Show other faction'] = 'Sincronizza le altre fazioni'
+L['Rank Filter'] = 'Filtro per rango'
+L['Include these ranks in the guild listing'] = 'Includi questi ranghi nella lista di gilda'


### PR DESCRIPTION
I localized missing strings in itIT.lua but mainly I changed the L['KEYSTONE'] string so the hyperlink is correctly recognized and rendered on italian clients.