### PR TITLE
Support TW reset time and refactor

### DIFF
--- a/AstralKeys.lua
+++ b/AstralKeys.lua
@@ -5,19 +5,32 @@ addon.EXPANSION_LEVEL = 70
 if not AstralKeys then AstralKeys = {} end
 if not AstralCharacters then AstralCharacters = {} end
 
-local initializeTime = {} 
+local initializeTime = {}
 initializeTime[1] = 1500390000 -- US Tuesday at reset
 initializeTime[2] = 1500447600 -- EU Wednesday at reset
-initializeTime[3] = 1500505200 -- CN Thursday at reset
+initializeTime[3] = 1500505200 -- TW Thursday at reset
 initializeTime[4] = 0
 
 function addon.WeekTime()
 	local region = GetCurrentRegion()
 
-	if region ~= 3 then
-		return GetServerTime() - initializeTime[1] - 604800 * addon.Week
-	else
+	if region == 3 then  -- EU
 		return GetServerTime() - initializeTime[2] - 604800 * addon.Week
+	elseif region == 4 then -- TW
+		return GetServerTime() - initializeTime[3] - 604800 * addon.Week
+	else                 -- default to US
+		return GetServerTime() - initializeTime[1] - 604800 * addon.Week
+	end
+end
+
+function addon.Week()
+	local region = GetCurrentRegion()
+	if region == 3 then  -- EU
+		return math.floor((GetServerTime() - initializeTime[2]) / 604800)
+	elseif region == 4 then -- TW
+		return math.floor((GetServerTime() - initializeTime[3]) / 604800)
+	else                 -- default to US
+		return math.floor((GetServerTime() - initializeTime[1]) / 604800)
 	end
 end
 
@@ -39,8 +52,36 @@ function addon.RefreshData()
 	InitData()
 end
 
-AstralEvents:Register('PLAYER_LOGIN', function()
+function addon.handleRegionReset(d, regionInitializeTime)
+	-- Create a frame
+	local frame = CreateFrame('FRAME')
+	frame.elapsed = 0
+	frame.first = true
+	frame.interval = 60 - d.sec
 
+	-- Set the frame's OnUpdate event handler
+	frame:SetScript('OnUpdate', function(self, elapsed)
+		self.elapsed = self.elapsed + elapsed
+		if self.elapsed > self.interval then
+			if self.first then
+				self.interval = 60
+				self.first = false
+			end
+
+			-- Check if the time is after the initialization time
+			if time(date('*t', GetServerTime())) > AstralKeysSettings.general.init_time then
+				addon.RefreshData()
+				addon.Week = math.floor((GetServerTime() - regionInitializeTime) / 604800)
+				self:SetScript('OnUpdate', nil)
+				self = nil
+				return nil
+			end
+			self.elapsed = 0
+		end
+	end)
+end
+
+AstralEvents:Register('PLAYER_LOGIN', function()
 	local major, minor = string.match(GetAddOnMetadata('AstralKeys', 'version'), '(%d+).(%d+)')
 
 	if tonumber(major) == 3 and tonumber(minor) > 25 and not AstralKeysSettings.wipedOldTables then -- Changed to single table in 3.26
@@ -62,13 +103,9 @@ AstralEvents:Register('PLAYER_LOGIN', function()
 	local region = GetCurrentRegion()
 	local currentTime = GetServerTime()
 	local d = date('*t', currentTime)
-	local hourOffset = math.modf(difftime(currentTime, time(date('!*t', currentTime))))/3600
+	local hourOffset = math.modf(difftime(currentTime, time(date('!*t', currentTime)))) / 3600
 
-	if region ~= 3 then -- Non EU
-		addon.Week = math.floor((GetServerTime() - initializeTime[1]) / 604800)
-	else
-		addon.Week = math.floor((GetServerTime() - initializeTime[2]) / 604800)
-	end
+	addon.Week = addon.Week()
 
 	addon.SetPlayerNameRealm()
 	addon.SetPlayerClass()
@@ -79,54 +116,14 @@ AstralEvents:Register('PLAYER_LOGIN', function()
 		AstralKeysSettings.general.init_time = addon.DataResetTime()
 	end
 
-	if d.wday == 3 and d.hour < (16 + hourOffset + (d.isdst and 1 or 0)) and region ~= 3 then
-		local frame = CreateFrame('FRAME')
-		frame.elapsed = 0
-		frame.first = true
-		frame.interval = 60 - d.sec
 
-		frame:SetScript('OnUpdate', function(self, elapsed)
-			self.elapsed = self.elapsed + elapsed
-			if self.elapsed > self.interval then
-				if self.first then
-					self.interval = 60
-					self.first = false
-				end
-
-				if time(date('*t', GetServerTime())) > AstralKeysSettings.general.init_time then		
-					addon.RefreshData()
-					addon.Week = math.floor((GetServerTime() - initializeTime[1]) / 604800)
-					self:SetScript('OnUpdate', nil)
-					self = nil
-					return nil
-				end
-				self.elapsed = 0
-			end
-			end)
-	elseif d.wday == 4 and d.hour < (7 + hourOffset + (d.isdst and 1 or 0)) and region == 3 then
-		local frame = CreateFrame('FRAME')
-		frame.elapsed = 0
-		frame.first = true
-		frame.interval = 60 - d.sec
-
-		frame:SetScript('OnUpdate', function(self, elapsed)
-			self.elapsed = self.elapsed + elapsed
-			if self.elapsed > self.interval then
-				if self.first then
-					self.interval = 60
-					self.first = false
-				end
-
-				if time(date('*t', GetServerTime())) > AstralKeysSettings.general.init_time then
-					addon.RefreshData()
-					addon.Week = math.floor((GetServerTime() - initializeTime[2]) / 604800)
-					self:SetScript('OnUpdate', nil)
-					self = nil
-					return nil
-				end
-				self.elapsed = 0
-			end
-			end)
+	if d.wday == 4 and d.hour < (7 + hourOffset + (d.isdst and 1 or 0)) and region == 3 then  --  EU Reset
+		addon.handleRegionReset(d, initializeTime[2])
+	elseif d.wday == 4 and d.hour < (7 + hourOffset + (d.isdst and 1 or 0)) and region == 4 then --  TW Reset
+		addon.handleRegionReset(d, initializeTime[3])
+		-- Handle non EU nor TW (US and other regions)
+	elseif d.wday == 3 and d.hour < (16 + hourOffset + (d.isdst and 1 or 0)) then -- US Reset (default)
+		addon.handleRegionReset(d, initializeTime[1])
 	end
 
 	-- Check over saved variables, remove any entries that are incorrect
@@ -148,7 +145,8 @@ AstralEvents:Register('PLAYER_LOGIN', function()
 	for i = 1, #AstralKeys do -- index guild units
 		if AstralKeys[i] and AstralKeys[i].unit then
 			addon.SetUnitID(AstralKeys[i].unit, i)
-			addon.AddUnitToSortTable(AstralKeys[i].unit, AstralKeys[i].btag, AstralKeys[i].class, AstralKeys[i].faction, AstralKeys[i].dungeon_id, AstralKeys[i].key_level, AstralKeys[i].weekly_best)
+			addon.AddUnitToSortTable(AstralKeys[i].unit, AstralKeys[i].btag, AstralKeys[i].class, AstralKeys[i].faction,
+				AstralKeys[i].dungeon_id, AstralKeys[i].key_level, AstralKeys[i].weekly_best)
 			--e.AddUnitToTable(AstralKeys[i].unit, AstralKeys[i].class, AstralKeys[i].faction, 'GUILD', AstralKeys[i].dungeon_id, AstralKeys[i].key_level, AstralKeys[i].weekly_best)
 		end
 	end
@@ -157,12 +155,11 @@ AstralEvents:Register('PLAYER_LOGIN', function()
 		if AstralCharacters[i] and AstralCharacters[i].unit then
 			addon.SetCharacterID(AstralCharacters[i].unit, i)
 		end
-	end	
-	
-	if AstralAffixes.season_start_week == 0 then -- Addon has just initialized for the fisrt time or saved variables have been lost. 
+	end
+
+	if AstralAffixes.season_start_week == 0 then -- Addon has just initialized for the fisrt time or saved variables have been lost.
 		AstralAffixes.season_start_week = addon.Week
 	end
-	C_MythicPlus.RequestMapInfo() -- Gets info on affixes and current season...
+	C_MythicPlus.RequestMapInfo()     -- Gets info on affixes and current season...
 	C_MythicPlus.RequestCurrentAffixes() -- Who knows what this actually does...
-
 end, 'login')


### PR DESCRIPTION
Hi thank for your plugin, it is very useful!

However I notice that TW region is not supported so every week astral key reset info at tue while our reset time is thur 7am HKT. So I created this PR to handle TW region. I also made a some refactoring to make the code shorter. 

Please review when you are free and let me know if it is good to merge!